### PR TITLE
Add PersonaCam

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ A curated list of resources for developers building visionOS apps, spatial inter
 - [KSPlayer](https://github.com/kingslay/KSPlayer) — Plays video with AVPlayer and FFmpeg across Apple platforms.
 - [HaishinKit.swift](https://github.com/shogo4405/HaishinKit.swift) — Streams camera and microphone media over RTMP and SRT.
 - [YouTubePlayerKit](https://github.com/SvenTiigi/YouTubePlayerKit) — Embeds YouTube playback in Swift apps across Apple platforms.
-- [I/O](https://github.com/comdigis-community/IO) - A multiplatform spatial audio engine written in Swift.
+- [I/O](https://github.com/comdigis-community/IO) — A multiplatform spatial audio engine written in Swift.
 - [PersonaCam](https://github.com/robomex/PersonaCam) — Adds a head-anchored Persona facecam for recording Apple Vision Pro demos.
 
 #### Build & Tooling

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ A curated list of resources for developers building visionOS apps, spatial inter
 - [HaishinKit.swift](https://github.com/shogo4405/HaishinKit.swift) — Streams camera and microphone media over RTMP and SRT.
 - [YouTubePlayerKit](https://github.com/SvenTiigi/YouTubePlayerKit) — Embeds YouTube playback in Swift apps across Apple platforms.
 - [I/O](https://github.com/comdigis-community/IO) - A multiplatform spatial audio engine written in Swift.
+- [PersonaCam](https://github.com/robomex/PersonaCam) — Adds a head-anchored Persona facecam for recording Apple Vision Pro demos.
 
 #### Build & Tooling
 


### PR DESCRIPTION
PersonaCam adds a head-anchored Persona facecam overlay for recording Apple Vision Pro demos, so the presenter's Persona stays in-frame in developer-recorded demo videos and tutorials. I built this tool.

Placed under Libraries → Media & Immersive Video. Entry follows the standard format, and `npm run lint` passes locally.

This PR also includes a one-character fix to the I/O entry (hyphen → em dash) so the Awesome lint check runs green again; it's been failing since #7.

Heads-up on the Link check job: it's been red since June 8, unrelated to this PR. The "Loading entities with ShaderGraph materials" link now 404s – Apple's WWDC26 restructure of the Reality Composer Pro docs may have removed the sample entirely. A similar live page is now at Designing materials with Shader Graph (https://developer.apple.com/documentation/realitycomposerpro/designing-materials-with-shader-graph), in case you'd rather retarget that entry than drop it.